### PR TITLE
Query params

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
     "node": true,
-    "esnext": true,
+    "esversion": 6,
     "bitwise": true,
     "camelcase": true,
     "curly": true,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "babel-polyfill": "^6.3.14",
     "debug": "^2.2.0",
-    "feathers-commons": "^0.6.0"
+    "feathers-commons": "^0.7.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",

--- a/src/client.js
+++ b/src/client.js
@@ -18,10 +18,10 @@ export default class Service {
       callback = args.pop();
     }
 
-    return new Promise(function(resolve, reject) => {
+    return new Promise((resolve, reject) => {
       args.unshift(`${this.path}::${method}`);
       args.push(function(error, data) {
-        if(callback) {
+        if (callback) {
           callback(error, data);
         }
 
@@ -33,27 +33,27 @@ export default class Service {
   }
 
   find(params = {}) {
-    return this.send('find', params.query);
+    return this.send('find', params.query || {});
   }
 
   get(id, params = {}) {
-    return this.send('get', id, params.query);
+    return this.send('get', id, params.query || {});
   }
 
   create(data, params = {}) {
-    return this.send('create', data, params.query);
+    return this.send('create', data, params.query || {});
   }
 
   update(id, data, params = {}) {
-    return this.send('update', id, data, params.query);
+    return this.send('update', id, data, params.query || {});
   }
 
   patch(id, data, params = {}) {
-    return this.send('patch', id, data, params.query);
+    return this.send('patch', id, data, params.query || {});
   }
 
   remove(id, params = {}) {
-    return this.send('remove', id, params.query);
+    return this.send('remove', id, params.query || {});
   }
 }
 

--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,4 @@
-import { methods, events } from './utils';
+import { events } from './utils';
 
 export default class Service {
   constructor(options) {
@@ -11,24 +11,14 @@ export default class Service {
   emit(... args) {
     this.connection[this.method](... args);
   }
-}
 
-const emitterMethods = ['on', 'once', 'off'];
-
-emitterMethods.forEach(method => {
-  Service.prototype[method] = function(name, callback) {
-    this.connection[method](`${this.path} ${name}`, callback);
-  };
-});
-
-methods.forEach(method => {
-  Service.prototype[method] = function(... args) {
+  send(method, ...args) {
     let callback = null;
-    if(typeof args[args.length - 1] === 'function') {
+    if (typeof args[args.length - 1] === 'function') {
       callback = args.pop();
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise(function(resolve, reject) => {
       args.unshift(`${this.path}::${method}`);
       args.push(function(error, data) {
         if(callback) {
@@ -40,5 +30,37 @@ methods.forEach(method => {
 
       this.connection[this.method](... args);
     });
+  }
+
+  find(params = {}) {
+    return this.send('find', params.query);
+  }
+
+  get(id, params = {}) {
+    return this.send('get', id, params.query);
+  }
+
+  create(data, params = {}) {
+    return this.send('create', data, params.query);
+  }
+
+  update(id, data, params = {}) {
+    return this.send('update', id, data, params.query);
+  }
+
+  patch(id, data, params = {}) {
+    return this.send('patch', id, data, params.query);
+  }
+
+  remove(id, params = {}) {
+    return this.send('remove', id, params.query);
+  }
+}
+
+const emitterMethods = ['on', 'once', 'off'];
+
+emitterMethods.forEach(method => {
+  Service.prototype[method] = function(name, callback) {
+    this.connection[method](`${this.path} ${name}`, callback);
   };
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,14 +1,5 @@
 import { hooks } from 'feathers-commons';
 
-export const methods = [
-  'find',
-  'get',
-  'create',
-  'update',
-  'patch',
-  'remove'
-];
-
 export const eventMappings = {
   create: 'created',
   update: 'updated',

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -31,7 +31,7 @@ describe('client', () => {
   });
 
   it('sends methods with acknowledgement', done => {
-    connection.on('todos::create', (data, callback) => {
+    connection.on('todos::create', (data, params, callback) => {
         data.created = true;
         callback(null, data);
     });


### PR DESCRIPTION
This makes it so we can pass params other than `query` params that head to the server. Effectively allowing us to use hooks on the client the same way you would on the server to pass data via params.

So you can client side params now look like this:

```js
{
 query: {
    name: 'bob'
 },
 token: 'auth token',
 headers: {
  'Content-Type': 'application/json'
 }
}
```

Only `params.query` will be passed on to the server.