### PR TITLE
Set connection max listeners and better debug messages

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
     "node": true,
-    "esversion": 6,
+    "esnext": true,
     "bitwise": true,
     "camelcase": true,
     "curly": true,

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,7 @@
 import { events } from './utils';
 
+const debug = require('debug')('feathers-socket-commons:client');
+
 export default class Service {
   constructor(options) {
     this.events = events;
@@ -27,7 +29,9 @@ export default class Service {
 
         return error ? reject(error) : resolve(data);
       });
-
+      
+      debug(`Sending socket.${this.method}`, args);
+      
       this.connection[this.method](... args);
     });
   }
@@ -61,6 +65,7 @@ const emitterMethods = ['on', 'once', 'off'];
 
 emitterMethods.forEach(method => {
   Service.prototype[method] = function(name, callback) {
+    debug(`Calling emitter method ${method} with event '${this.path} ${name}'`);
     this.connection[method](`${this.path} ${name}`, callback);
   };
 });

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import { each, stripSlashes } from 'feathers-commons';
 import { setupMethodHandlers } from './methods';
 import { filterMixin, setupEventHandlers } from './events';
 
+const debug = require('debug')('feathers-socket-commons');
+
 function socketMixin(service) {
   if(typeof service.mixin !== 'function') {
     return;
@@ -9,21 +11,30 @@ function socketMixin(service) {
 
   service.mixin({
     setup(app, path) {
-      const info = app._socketInfo;
-      const mountpath = (app.mountpath !== '/' && typeof app.mountpath === 'string') ?
-          app.mountpath : '';
-      const fullPath = stripSlashes(`${mountpath}/${path}`);
-      const setupSocket = socket => {
-        setupMethodHandlers.call(app, info, socket, fullPath, this);
-      };
+      if(!this._socketSetup) {
+        const info = app._socketInfo;
+        const connection = info.connection();
+        const mountpath = (app.mountpath !== '/' && typeof app.mountpath === 'string') ?
+            app.mountpath : '';
+        const fullPath = stripSlashes(`${mountpath}/${path}`);
+        const setupSocket = socket => {
+          setupMethodHandlers.call(app, info, socket, fullPath, this);
+        };
+        
+        debug(`Registering socket handlers for service at '${fullPath}'`);
 
-      // Set up event handlers for this service
-      setupEventHandlers.call(app, info, fullPath, this);
-      // For a new connection, set up the service method handlers
-      info.connection().on('connection', setupSocket);
-      // For any existing connection add method handlers
-      each(info.clients(), setupSocket);
-
+        // Set up event handlers for this service
+        setupEventHandlers.call(app, info, fullPath, this);
+        // For a new connection, set up the service method handlers
+        connection.on('connection', setupSocket);
+        // For any existing connection add method handlers
+        each(info.clients(), setupSocket);
+      } else {
+        debug(`Sockets on ${path} already set up`);
+      }
+      
+      this._socketSetup = true;
+      
       if(typeof this._super === 'function') {
         return this._super.apply(this, arguments);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ function socketMixin(service) {
     setup(app, path) {
       if(!this._socketSetup) {
         const info = app._socketInfo;
+        const serviceCount = Object.keys(app.services).length;
         const connection = info.connection();
         const mountpath = (app.mountpath !== '/' && typeof app.mountpath === 'string') ?
             app.mountpath : '';
@@ -25,6 +26,9 @@ function socketMixin(service) {
 
         // Set up event handlers for this service
         setupEventHandlers.call(app, info, fullPath, this);
+        // Update the number of max listener to the service count
+        // This will still catch memory leaks
+        connection.setMaxListeners(serviceCount + 1);
         // For a new connection, set up the service method handlers
         connection.on('connection', setupSocket);
         // For any existing connection add method handlers

--- a/src/methods.js
+++ b/src/methods.js
@@ -1,6 +1,8 @@
 import { getArguments } from 'feathers-commons';
 import { errorObject } from './utils';
 
+const debug = require('debug')('feathers-socket-commons:methods');
+
 // The position of the params parameters for a service method so that we can extend them
 // default is 1
 export const paramsPositions = {
@@ -22,12 +24,15 @@ export function setupMethodHandlers(info, socket, path, service) {
       paramsPositions[method] : 1;
 
     socket.on(name, function () {
+      debug(`Got '${name}' event with connection`, params);
+      
       try {
         let args = getArguments(method, arguments);
         args[position] = Object.assign({ query: args[position] }, params);
         service[method].apply(service, args);
       } catch(e) {
         let callback = arguments[arguments.length - 1];
+        debug(`Error on socket`, e);
         if(typeof callback === 'function') {
           callback(errorObject(e));
         }


### PR DESCRIPTION
This pull request adds a bunch of debug messages since it is sometimes not easy to catch errors in websocket connections.

Also increases the socket connection max event listeners for each new service and prevents sockets from being set up twice (when calling the services `.setup` twice).

Closes https://github.com/feathersjs/feathers/issues/222