### PR TITLE
Allow chaining event listeners.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -67,5 +67,6 @@ emitterMethods.forEach(method => {
   Service.prototype[method] = function(name, callback) {
     debug(`Calling emitter method ${method} with event '${this.path} ${name}'`);
     this.connection[method](`${this.path} ${name}`, callback);
+    return this;
   };
 });

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -13,6 +13,12 @@ describe('client', () => {
     events
   });
 
+  it('allows chaining event listeners', done => {
+    assert.equal(service, service.on('thing', () => {}));
+    assert.equal(service, service.once('other thing', () => {}));
+    done();
+  });
+
   it('initializes and emits events', done => {
     connection.once('test', data => {
       assert.deepEqual(data, testData);


### PR DESCRIPTION
This allows the [examples](http://docs.feathersjs.com/clients/primus.html) to work like this:

```js
messageService
  .on('created', function(message) {
    console.log('Someone created a message', message);
  })
  .on('updated', function(message) {
    console.log('Someone updated a message', message);
  });
```

The tests don't check for [the `off` event](https://github.com/feathersjs/feathers-socket-commons/blob/master/src/client.js#L64), because calling it throws errors. I assume it's no longer supported?