### PR TITLE
Remove connection setMaxListeners

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,32 +13,27 @@ function socketMixin(service) {
     setup(app, path) {
       if(!this._socketSetup) {
         const info = app._socketInfo;
-        const serviceCount = Object.keys(app.services).length;
-        const connection = info.connection();
         const mountpath = (app.mountpath !== '/' && typeof app.mountpath === 'string') ?
             app.mountpath : '';
         const fullPath = stripSlashes(`${mountpath}/${path}`);
         const setupSocket = socket => {
           setupMethodHandlers.call(app, info, socket, fullPath, this);
         };
-        
+
         debug(`Registering socket handlers for service at '${fullPath}'`);
 
         // Set up event handlers for this service
         setupEventHandlers.call(app, info, fullPath, this);
-        // Update the number of max listener to the service count
-        // This will still catch memory leaks
-        connection.setMaxListeners(serviceCount + 1);
         // For a new connection, set up the service method handlers
-        connection.on('connection', setupSocket);
+        info.connection().on('connection', setupSocket);
         // For any existing connection add method handlers
         each(info.clients(), setupSocket);
       } else {
         debug(`Sockets on ${path} already set up`);
       }
-      
+
       this._socketSetup = true;
-      
+
       if(typeof this._super === 'function') {
         return this._super.apply(this, arguments);
       }


### PR DESCRIPTION
Related to https://github.com/feathersjs/feathers-socket-commons/issues/10. Instead we just set the max listeners to a higher number in `feathers-socketio` and `feathers-primus` and add an entry to the FAQ if somebody does get that warning.