### PR TITLE
Support timeouts for socket clients

### DIFF
--- a/test/client.test.js
+++ b/test/client.test.js
@@ -9,6 +9,7 @@ describe('client', () => {
   const service = new Service({
     name: 'todos',
     method: 'emit',
+    timeout: 50,
     connection,
     events
   });
@@ -38,12 +39,19 @@ describe('client', () => {
 
   it('sends methods with acknowledgement', done => {
     connection.on('todos::create', (data, params, callback) => {
-        data.created = true;
-        callback(null, data);
+      data.created = true;
+      callback(null, data);
     });
 
     service.create(testData).then(result => {
       assert.ok(result.created);
+      done();
+    });
+  });
+
+  it('times out on undefined methods', done => {
+    service.remove(10).catch(error => {
+      assert.equal(error.message, 'Timeout of 50ms exceeded calling todos::remove');
       done();
     });
   });


### PR DESCRIPTION
After a release, feathers-socketio and feathers-primus need to be updated to take a `app.get('feathers-timeout')` option into consideration.

Closes #9, closes https://github.com/feathersjs/feathers-client/issues/42