### PR TITLE
Make service off method be namespaced

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -7,6 +7,7 @@ const namespacedEmitterMethods = [
   'emit',
   'listenerCount',
   'listeners',
+  'off',
   'on',
   'once',
   'prependListener',
@@ -32,6 +33,11 @@ const addEmitterMethods = service => {
   });
 
   namespacedEmitterMethods.forEach(method => {
+    // Only set off if it's a method on connection
+    if (method === 'off' && typeof service.connection[method] !== 'function') {
+      return;
+    }
+
     service[method] = function(name, ...args) {
       if(typeof this.connection[method] !== 'function') {
         throw new Error(`Can not call '${method}' on the client service connection.`);
@@ -115,12 +121,11 @@ export default class Service {
   }
 
   off(... args) {
-    if(typeof this.connection.off === 'function') {
-      return this.connection.off(... args);
-    } else if(args.length === 1) {
+    // Note: if .off() is defined on connection, this method is replaced with namespaced method
+    if(args.length === 1) {
       return this.removeAllListeners(... args);
     }
 
-    return this.removeEventListener(... args);
+    return this.removeListener(... args);
   }
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -98,4 +98,45 @@ describe('client', () => {
 
     connection.emit('todos test', testData);
   });
+
+  it('properly handles on/off methods', done => {
+    const testData = { hello: 'world' };
+
+    const callback1 = data => {
+      assert.deepEqual(data, testData);
+      assert.equal(service.listenerCount('test'), 3);
+      service.off('test', callback1);
+      assert.equal(service.listenerCount('test'), 2);
+      service.off('test');
+      assert.equal(service.listenerCount('test'), 0);
+      done();
+    };
+    const callback2 = () => {
+      // noop
+    };
+
+    service.on('test', callback1);
+    service.on('test', callback2);
+    service.on('test', callback2);
+
+    connection.emit('todos test', testData);
+  });
+
+  it('forwards namespaced call to .off', done => {
+    // Use it's own connection and service so off method gets detected
+    const connection = new EventEmitter();
+    connection.off = name => {
+      assert.equal(name, 'todos test');
+      done();
+    };
+
+    const service = new Service({
+      name: 'todos',
+      method: 'emit',
+      timeout: 50,
+      connection,
+      events
+    });
+    service.off('test');
+  });
 });


### PR DESCRIPTION
Fixes calls to service.off not actually removing the listeners if the connection has an off method, also fixed the shimmed version calling a non-existent method