### PR TITLE
Normalize arguments when client sends packed data.

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -1,5 +1,5 @@
 import {getArguments} from 'feathers-commons';
-import {normalizeError} from './utils';
+import {normalizeError, normalizeArgs} from './utils';
 
 const debug = require('debug')('feathers-socket-commons:methods');
 
@@ -29,7 +29,7 @@ export function setupMethodHandlers (info, socket, path, service) {
       debug(`Got '${name}' event with connection`, connection);
 
       try {
-        let args = getArguments(method, arguments);
+        let args = getArguments(method, normalizeArgs(arguments));
         let callback = args[args.length - 1];
 
         // NOTE (EK): socket.io just bombs silently if there is an error that

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,3 +39,13 @@ export function normalizeError (e) {
 
   return result;
 }
+
+export function normalizeArgs (args) {
+  let ret = [];
+  if (args.length === 2 && Array.isArray(args['0'])) {
+    ret = args[0];
+    ret.push(args[1]);
+    return ret;
+  }
+  return args;
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { convertFilterData, promisify, normalizeError } from '../src/utils';
+import { convertFilterData, promisify, normalizeError, normalizeArgs } from '../src/utils';
 
 describe('utils', () => {
   it('convertFilterData', () => {
@@ -54,5 +54,25 @@ describe('utils', () => {
     assert.ok(typeof obj.hook === 'undefined');
     assert.equal(obj.message, 'Testing');
     assert.equal(obj.expando, true);
+  });
+
+  it('normalizeArgs', () => {
+    const usualArgs = [ undefined, { test: true }, function () { } ];
+    const packedArgs = [ [ undefined, { test: true } ], function () { } ];
+    const usualArgsWithArray = [ [ undefined, { test: true } ], {}, function () { } ];
+
+    const normalizedUsualArgs = normalizeArgs(usualArgs);
+    const normalizedPackedArgs = normalizeArgs(packedArgs);
+    const normalizedUsualArgsWithArray = normalizeArgs(usualArgsWithArray);
+
+    assert.equal(usualArgs[0], normalizedUsualArgs[0]);
+    assert.deepEqual(usualArgs[1], normalizedUsualArgs[1]);
+    assert.equal(normalizedUsualArgs.length, 3);
+
+    assert.equal(usualArgs[0], normalizedPackedArgs[0]);
+    assert.deepEqual(usualArgs[1], normalizedPackedArgs[1]);
+    assert.equal(normalizedPackedArgs.length, 3);
+
+    assert.equal(normalizedUsualArgsWithArray.length, 3);
   });
 });


### PR DESCRIPTION
Hi,

In the case of SocketCluster that accepts only 3 arguments, the second one being the data, in the client side I'm packing the data arguments into an array.

When received serverside in case of only 2 arguments (data + callback) and first argument being an array, normalizeArgs function unpacks the arguments to a full normal array as it can be done with SocketIO and Primus adapters.

There is a weak point: the client could not send only one data as array, but the usecase doesn't exists in Feathers client.

Best,
Paul